### PR TITLE
Center graph

### DIFF
--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -174,7 +174,6 @@ export default {
       let currentWidth = parseInt(d3.select("#canvas").style("width"), 10);
       svg.attr("width", currentWidth);
     },
-
     renderGraph() {
       var self = this;
 
@@ -199,10 +198,8 @@ export default {
       });
       svg.call(zoom);
 
-      // Create the renderer
+      // Create and run the renderer
       var render = new dagreD3.render();
-
-      // Run the renderer. This is what draws the final graph.
       render(inner, this.graph);
 
       //Select all nodes and add click event
@@ -243,7 +240,6 @@ export default {
           )
           .scale(initialScale)
       );
-
       svg.attr("height", this.graph.graph().height * initialScale + 40);
     },
   },


### PR DESCRIPTION
The graph is now centred in the canvas. It also re-centers the graph when you click on a child node. It also responsive depending on the view-width.

Before
<img width="1680" alt="Screenshot 2020-09-07 at 14 42 16" src="https://user-images.githubusercontent.com/48738452/92384212-55d8c480-f118-11ea-917c-67c900c6c288.png">

After
<img width="1679" alt="Screenshot 2020-09-07 at 14 42 38" src="https://user-images.githubusercontent.com/48738452/92384240-625d1d00-f118-11ea-8476-0cf6f6ca1ace.png">
